### PR TITLE
Fix spaces in email addresses

### DIFF
--- a/api/.nextRelease/api.js
+++ b/api/.nextRelease/api.js
@@ -109,7 +109,7 @@ Generator.prototype.generate = function(cb) {
       postcode: range(10000, 99999)
     });
 
-    this.include('email', name[0] + '.' + name[1].replace(' ', '') + '@example.com');
+    this.include('email', name[0] + '.' + name[1].replace(/ /g, '') + '@example.com');
 
     var salt = random(2, 8);
     this.include('login', {

--- a/api/1.0/api.js
+++ b/api/1.0/api.js
@@ -109,7 +109,7 @@ Generator.prototype.generate = function(cb) {
       postcode: range(10000, 99999)
     });
 
-    this.include('email', name[0] + '.' + name[1].replace(' ', '') + '@example.com');
+    this.include('email', name[0] + '.' + name[1].replace(/ /g, '') + '@example.com');
 
     var salt = random(2, 8);
     this.include('login', {


### PR DESCRIPTION
Occurring when the last name consists of 3 or more words, only the first space would be replaced

Fixes #72