### PR TITLE
Fix AVS number, which is digits-only.

### DIFF
--- a/api/.nextRelease/data/CH/inject.js
+++ b/api/.nextRelease/data/CH/inject.js
@@ -15,7 +15,7 @@ module.exports = (inc, contents) => {
     include(inc, 'cell', '(' + random(3, 3) + ')-' + random(3, 3) + '-' + random(3, 4));
     include(inc, 'id', {
         name: 'AVS',
-        value: '756.' + random(4, 4) + '.' + random(4, 4) + '.' + random(3, 2)
+        value: '756.' + random(3, 4) + '.' + random(3, 4) + '.' + random(3, 2)
     });
     include(inc, 'picture', pic);
 };


### PR DESCRIPTION
See https://www.bsv.admin.ch/bsv/fr/home/assurances-sociales/ahv/donnees-de-base-et-legislation/quels-sont-les-elements-qui-composent-le-numero-d-assure-.html for reference.