### PR TITLE
Format CA postal codes properly

### DIFF
--- a/api/.nextRelease/data/CA/inject.js
+++ b/api/.nextRelease/data/CA/inject.js
@@ -8,5 +8,13 @@ module.exports = (inc, contents) => {
         name: '',
         value: null
     });
+    include(inc, 'location', () => {
+      var letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+      var postcode = letters[range(0,25)] + random(3, 1) + letters[range(0,25)] + ' ' + random(3, 1) + letters[range(0,25)] + random(3, 1);
+
+      contents.location.postcode = postcodes;
+    });
+
     include(inc, 'picture', pic);
 };


### PR DESCRIPTION
This should create proper Canadian postal codes in A1A 1A1 format.