### PR TITLE
fix Norwegian id generation

### DIFF
--- a/api/.nextRelease/data/NO/inject.js
+++ b/api/.nextRelease/data/NO/inject.js
@@ -39,7 +39,7 @@ module.exports = (inc, contents) => {
       } else if (year >= 1900 && year <= 1999) {
         no = 499 - range(0, 499);
       }
-      if ( ((no & 1) && isMale) || (!(no & 1) && !isMale) ) {
+      if ( ((no & 1) && !isMale) || (!(no & 1) && isMale) ) {
         no--;
       }
       no = pad(String(no), 3);


### PR DESCRIPTION
Hey.

Decided to use this at work to generate new users and our application was rejecting the user because the ids were incorrect.

The individual number part of the id has to be even for women and odd for men. The values were being generated in the opposite way.

https://en.wikipedia.org/wiki/National_identification_number#Norway