### PR TITLE
Format GB cell numbers as 07xxx xxxxxx

### DIFF
--- a/api/.nextRelease/data/GB/inject.js
+++ b/api/.nextRelease/data/GB/inject.js
@@ -29,7 +29,7 @@ module.exports = (inc, contents) => {
       contents.phone = randomItem(phones);
     });
 
-    include(inc, contents, 'cell', '07' + random(3, 2) + '-' + random(3, 3) + '-' + random(3, 3));
+    include(inc, contents, 'cell', '07' + random(3, 3) + ' ' + random(3, 6));
 
     include(inc, contents, 'location', () => {
       const code = 'ABDEFGHJLNPQRSTUWXYZ';


### PR DESCRIPTION
As mentioned in #123, GB mobile numbers are not currently valid.

This PR changes the generator to create numbers in the format `07xxx xxxxxx`.