### PR TITLE
Fix boundary breaking password generation bug

### DIFF
--- a/api/.nextRelease/api.js
+++ b/api/.nextRelease/api.js
@@ -366,7 +366,7 @@ class Generator {
       max = min;
     }
     min = min > 64 || min < 1 || min === undefined || isNaN(min) ? 8 : min;
-    max = max > 64 || max < 1 || max === undefined || isNaN(max) ? 64 : max;
+    max = max > 64 || max < 1 || max === undefined || isNaN(max) || max < min ? 64 : max;
 
     let passLen = range(min, max);
 

--- a/api/1.1/api.js
+++ b/api/1.1/api.js
@@ -335,7 +335,7 @@ class Generator {
       max = min;
     }
     min = min > 64 || min < 1 || min === undefined || isNaN(min) ? 8 : min;
-    max = max > 64 || max < 1 || max === undefined || isNaN(max) ? 64 : max;
+    max = max > 64 || max < 1 || max === undefined || isNaN(max) || max < min ? 64 : max;
   
     let passLen = range(min, max);
   

--- a/api/1.2/api.js
+++ b/api/1.2/api.js
@@ -363,7 +363,7 @@ class Generator {
       max = min;
     }
     min = min > 64 || min < 1 || min === undefined || isNaN(min) ? 8 : min;
-    max = max > 64 || max < 1 || max === undefined || isNaN(max) ? 64 : max;
+    max = max > 64 || max < 1 || max === undefined || isNaN(max) || max < min ? 64 : max;
   
     let passLen = range(min, max);
   

--- a/api/1.3/api.js
+++ b/api/1.3/api.js
@@ -366,7 +366,7 @@ class Generator {
       max = min;
     }
     min = min > 64 || min < 1 || min === undefined || isNaN(min) ? 8 : min;
-    max = max > 64 || max < 1 || max === undefined || isNaN(max) ? 64 : max;
+    max = max > 64 || max < 1 || max === undefined || isNaN(max) || max < min ? 64 : max;
   
     let passLen = range(min, max);
   


### PR DESCRIPTION
There's a bug present in api versions v1.1, v1.2, v1.3, and nextRelease that enables someone to request random users with password lengths of up to ~32,000 characters. Which is well above the 64 character intended boundary.

This happens when the mersenne.rand call inside the range function is called with a parameter of 0.

This is possible to cause if the api password parameter is called with a length range of values 0 and 7.
Such as: api/?password=lower,0-7
When the code generates a password with these values it'll firstly set the 0 value to 8 as the check for min < 1 will be met and cause it to default it's value. This will then cause the values to end up as 8 and 7 to be used in mersenne.rand. 8 as min, and 7 as max. Resulting in it executing as so mersenne.rand(7 - 8 + 1).

When this password generation bug is combined with requesting a large amount of results from the api it causes the app to crash with the error "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory".

The fix I've commited is an extra check to the max value that is set before the range function is called. The extra check will allow the max value to get defaulted if it's lower than the min value (max < min). I've commited this change to all affected versions of the api.