### PR TITLE
fix(us-ssn-generation): added checks for valid SSN generation

### DIFF
--- a/api/.nextRelease/data/US/inject.js
+++ b/api/.nextRelease/data/US/inject.js
@@ -6,9 +6,22 @@ module.exports = (inc, contents) => {
 
     include(inc, contents, 'phone', '(' + random(4, 1) + random(3, 2) + ') ' + random(4, 1) + random(3, 2) + '-' + random(3, 4));
     include(inc, contents, 'cell', '(' + random(4, 1) + random(3, 2) + ') ' + random(4, 1) + random(3, 2) + '-' + random(3, 4));
-    include(inc, contents, 'id', {
-        name: 'SSN',
-        value: random(3, 3) + '-' + random(3, 2) + '-' + random(3, 4)
+    include(inc, contents, 'id', () => {
+        const checkSSN = (ssn) => {
+            const regex = new RegExp("^(?!219-09-9999|078-05-1120)(?!666|000|9\\d{2})\\d{3}-(?!00)\\d{2}-(?!0{4})\\d{4}$");
+            return regex.test(ssn);
+        };
+        const genSSN = () => {
+            let ssn = random(3, 3) + '-' + random(3, 2) + '-' + random(3, 4);
+            while(!checkSSN(ssn)){
+                ssn = random(3, 3) + '-' + random(3, 2) + '-' + random(3, 4);
+            }
+            return ssn;
+        };
+        contents.id = {
+            name: 'SSN',
+            value: genSSN()
+        }
     });
     include(inc, contents, 'picture', pic);
 };


### PR DESCRIPTION
As I was using the API, I realized that the API can potentially generate invalid Social Security Numbers. There are different rules for valid SSN such as not beginning with "666", as specified in this article: 

https://www.codeproject.com/Articles/651609/Validating-Social-Security-Numbers-through-Regular

The regex expression I included in the fix originates from this article as well. The article abides by CPOL:
https://www.codeproject.com/info/cpol10.aspx