### PR TITLE
Correct response code when rate limit is exceeded

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -66,7 +66,7 @@ async function genUser(req, res, version) {
   const ip = req.headers['cf-connecting-ip'] || req.headers['x-real-ip'] || req.headers['x-forwarded-for'] || req.connection.remoteAddress;
 
   if (process.env.spec !== "true" && clients[ip] >= settings.limit) {
-    return res.status(503).json({
+    return res.status(429).json({
       error: `Whoa, ease up there cowboy. You've requested ${clients[ip]} users in the last minute. Help us keep this service free and spare some bandwidth for other users please :)`
     });
   }


### PR DESCRIPTION
429 Rate Limit Exceeded response when there are too many requests.
I am using this API in a personal project and it would be great to be able to use this status code to know when to back off and take a pause.