### PR TITLE
Correct How-To results:location:street

### DIFF
--- a/views/pages/documentation.ejs
+++ b/views/pages/documentation.ejs
@@ -65,7 +65,10 @@ $.ajax({
         "last": "<span>gibson</span>"
       },
       "location": {
-        "street": "<span>9278 new road</span>",
+        "street": {
+          "number": "<span>9278</span>",
+          "name": "<span>new road</span>",
+        }, 
         "city": "<span>kilcoole</span>",
         "state": "<span>waterford</span>",
         "postcode": "<span>93027</span>",


### PR DESCRIPTION
street data needed to be split on the example docs to include both street.name and street.number.  Ran into issue when using api to create user pages using your AWESOME api! Thanks for everything you do!