### PR TITLE
Add CPF as Brazil's ID

### DIFF
--- a/api/.nextRelease/data/BR/inject.js
+++ b/api/.nextRelease/data/BR/inject.js
@@ -7,8 +7,8 @@ module.exports = (inc, contents) => {
     include(inc, contents, 'phone', '(' + random(3, 2) + ') ' + random(3, 4) + '-' + random(3, 4));
     include(inc, contents, 'cell', '(' + random(3, 2) + ') ' + random(3, 4) + '-' + random(3, 4));
     include(inc, contents, 'id', {
-        name: '',
-        value: null
+        name: 'CPF',
+        value: random(3, 3) + '.' + random(3, 3) + '.' + random(3, 3) + '-' + random(3, 2)
     });
     include(inc, contents, 'picture', pic);
 };


### PR DESCRIPTION
Brazil's CPF (Cadastro de Pessoas Físicas) can be considered a national ID and is comprised of 11 digits in the format 000.000.000-00: https://en.wikipedia.org/wiki/CPF_number

An alternative for CPF could be RG (Registro Geral), but curiously it is not unique as each Brazilian state can issue independent numbers (and thus allow duplication): https://en.wikipedia.org/wiki/Brazilian_identity_card