### PR TITLE
Allow setting http port via env var

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ app.set('view engine', 'ejs');
 
 // middleware
 app.use(favicon(path.join(__dirname, 'public', 'img', 'favicon.png')));
-app.set('port', settings.port);
+app.set('port', process.env.HTTP_PORT || settings.port);
 //app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));


### PR DESCRIPTION
This allows you to set the http port for the server via the HTTP_PORT env var. It makes it easier to run locally without colliding ports with other projects and not requiring any source changes.