### PR TITLE
Exit on startup when MongoDB connection fails

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const http         = require('http');
 const compress     = require('compression');
 const cors         = require('cors');
 
-const db       = require('./models/db')(process.env.spec);
+const db       = require('./models/db')
 const index    = require('./routes/index');
 const api      = require('./routes/api');
 const stats    = require('./routes/stats');
@@ -16,7 +16,6 @@ const store    = require('./store');
 
 const app    = express();
 const server = http.createServer(app);
-require('./sockets.js')(server);
 
 // view engine setup
 app.set('views', path.join(__dirname, '.viewsMin'));
@@ -53,7 +52,9 @@ app.use((err, req, res, next) => {
 
 // Load and initialize generators before starting server
 (async() => {
+  await db(process.env.spec);
   await require('./loadGenerators')();
+  require('./sockets.js')(server);
   startServer();
 })();
 

--- a/models/db.js
+++ b/models/db.js
@@ -1,17 +1,24 @@
 const mongoose = require('mongoose');
 const settings = require('../settings');
 
-module.exports = testEnv => {
+module.exports = async testEnv => {
   const dbName = settings.db + (testEnv ? '-test' : '');
 
-  mongoose.connect('mongodb://localhost/' + dbName, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useFindAndModify: false,
-  });
-  mongoose.set('useCreateIndex', true);
-
   const db = mongoose.connection;
+  db.on('connecting', console.log.bind(console, '[database] Connecting to MongoDB...'));
   db.on('connected', console.log.bind(console, '[database] Connected to MongoDB.'));
-  db.on('error', console.error.bind(console, '[database] Error occured while connecting to MongoDB.'));
+  db.on('error', console.error.bind(console, '[database] Error occured in MongoDB connection.'));
+
+  try {
+    await mongoose.connect('mongodb://localhost/' + dbName, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useFindAndModify: false,
+    });
+  } catch (err) {
+    console.error('[database] Error occured while connecting to MongoDB. Is it running?');
+    process.exit(1);
+  }
+
+  mongoose.set('useCreateIndex', true);
 };


### PR DESCRIPTION
Waits for MongoDB connection before starting the application and exits if the connection fails with error message. Currently the application starts but crashes once a request is made to the DB when it fails to connect initially.

The error event that exists is only triggered when there are errors in the connection after its been established. Awaiting the connection and logging on catch will get the failure to connect.