### PR TITLE
Include new nats for 1.4 in tests

### DIFF
--- a/spec/api/modern/1.0.js
+++ b/spec/api/modern/1.0.js
@@ -19,8 +19,13 @@ module.exports = (server, version=defVersion) => {
   ];
 
   // Include NO nat for versions 1.2+
-  if (version !== "1.0" && version !== "1.1") {
+  if (parseFloat(version) >= 1.2) {
     nats.push('NO');
+  }
+
+  // Include IN, MX, RS, UA for versions 1.4+
+  if (parseFloat(version) >= 1.4) {
+    nats.push('IN', 'MX', 'RS', 'UA')
   }
 
   // Include fields


### PR DESCRIPTION
The "should retrieve random nat when invalid nat is specified" test is flaky right now for 1.4 when it randomly uses one of the nats not in the existing list